### PR TITLE
Build the HTTP client on Windows and Linux

### DIFF
--- a/Release/include/cpprest/http_client.h
+++ b/Release/include/cpprest/http_client.h
@@ -60,16 +60,13 @@ typedef void* native_handle;
 
 #include "cpprest/oauth2.h"
 
-#if !defined(_WIN32) && !defined(__cplusplus_winrt) || defined(CPPREST_FORCE_HTTP_CLIENT_ASIO)
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wconversion"
-#endif
-#include "boost/asio/ssl.hpp"
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
-#endif
+namespace boost {
+namespace asio {
+namespace ssl {
+class context;
+} // namespace ssl
+} // namespace asio
+} // namespace boost
 
 /// The web namespace contains functionality common to multiple protocols like HTTP and WebSockets.
 namespace web

--- a/Release/src/http/common/http_compression.cpp
+++ b/Release/src/http/common/http_compression.cpp
@@ -32,6 +32,10 @@
 
 #if defined(CPPREST_HTTP_COMPRESSION)
 #include <zlib.h>
+// zconf.h may define compress
+#ifdef compress
+#undef compress
+#endif
 #if !defined(CPPREST_EXCLUDE_BROTLI)
 #define CPPREST_BROTLI_COMPRESSION
 #endif // CPPREST_EXCLUDE_BROTLI

--- a/Release/src/pch/stdafx.h
+++ b/Release/src/pch/stdafx.h
@@ -97,10 +97,12 @@
 #include "cpprest/details/web_utilities.h"
 
 // http
-//#include "cpprest/details/http_helpers.h"
-//#include "cpprest/http_client.h"
-//#include "cpprest/http_headers.h"
-//#include "cpprest/http_msg.h"
+#if defined(RTC_WINDOWS_FAMILY) || defined(RTC_LINUX_FAMILY)
+#include "cpprest/details/http_helpers.h"
+#include "cpprest/http_client.h"
+#include "cpprest/http_headers.h"
+#include "cpprest/http_msg.h"
+#endif
 
 // oauth
 #if !defined(_WIN32) || _WIN32_WINNT >= _WIN32_WINNT_VISTA

--- a/cpprest.lua
+++ b/cpprest.lua
@@ -152,10 +152,6 @@ project "cpprest"
 
     configuration { "linux" }
 
-      defines {
-        "BOOST_DISABLE_OPENSSL_INIT",
-      }
-
       files {
         t_httpfiles,
         "Release/src/http/client/http_client_asio.cpp",
@@ -343,10 +339,6 @@ project "cpprest"
     -- project specific configuration settings
 
     configuration { "android*" }
-
-      defines {
-        "BOOST_DISABLE_OPENSSL_INIT",
-      }
 
       files {
         t_httpfiles,

--- a/cpprest.lua
+++ b/cpprest.lua
@@ -22,6 +22,8 @@ project "cpprest"
   defines {
     "_NO_PPLXIMP", -- prevent building a dynamic library
     "_NO_ASYNCRTIMP",
+    "CPPREST_EXCLUDE_BROTLI",
+    "CPPREST_EXCLUDE_WEBSOCKETS",
   }
 
   files {
@@ -37,6 +39,22 @@ project "cpprest"
     "Release/src/pch",
     "Release/include",
     "../boost",
+    "../zlib",
+  }
+
+  local t_httpfiles = {
+    "Release/src/http/client/http_client.cpp",
+    "Release/src/http/client/http_client_msg.cpp",
+    "Release/src/http/common/http_compression.cpp",
+    "Release/src/http/common/http_helpers.cpp",
+    "Release/src/http/common/http_msg.cpp",
+    "Release/src/http/oauth/oauth1.cpp",
+    "Release/src/http/oauth/oauth2.cpp",
+    "Release/src/json/json.cpp",
+    "Release/src/json/json_parsing.cpp",
+    "Release/src/json/json_serialization.cpp",
+    "Release/src/utilities/base64.cpp",
+    "Release/src/utilities/web_utilities.cpp",
   }
 
   -- -------------------------------------------------------------
@@ -61,6 +79,8 @@ project "cpprest"
       }
 
       files {
+        t_httpfiles,
+        "Release/src/http/client/http_client_winhttp.cpp",
         "Release/src/pplx/pplxwin.cpp",
       }
 
@@ -132,8 +152,20 @@ project "cpprest"
 
     configuration { "linux" }
 
+      defines {
+        "BOOST_DISABLE_OPENSSL_INIT",
+      }
+
       files {
+        t_httpfiles,
+        "Release/src/http/client/http_client_asio.cpp",
+        "Release/src/http/client/x509_cert_utilities.cpp",
         "Release/src/pplx/pplxlinux.cpp",
+        "Release/src/pplx/threadpool.cpp",
+      }
+
+      includedirs {
+        "../openssl/include",
       }
 
     -- -------------------------------------------------------------
@@ -312,8 +344,20 @@ project "cpprest"
 
     configuration { "android*" }
 
+      defines {
+        "BOOST_DISABLE_OPENSSL_INIT",
+      }
+
       files {
+        t_httpfiles,
+        "Release/src/http/client/http_client_asio.cpp",
+        "Release/src/http/client/x509_cert_utilities.cpp",
         "Release/src/pplx/pplxlinux.cpp",
+        "Release/src/pplx/threadpool.cpp",
+      }
+
+      includedirs {
+        "../openssl/include",
       }
 
     -- -------------------------------------------------------------
@@ -433,6 +477,8 @@ project "cpprest"
       }
 
       files {
+        t_httpfiles,
+        "Release/src/http/client/http_client_winrt.cpp",
         "Release/src/pplx/pplxwin.cpp",
       }
 


### PR DESCRIPTION
**Issue(s)**
https://devtopia.esri.com/runtime/millennium-falcon/issues/142

This PR makes the HTTP client to be built so it can be used by our HTTP request handler implementation in core (https://devtopia.esri.com/runtime/runtimecore/pull/11391).

The http client is only built for Windows and Linux platforms.

The OpenSSL repo has already been updated.

3rdparty vTest x64: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/dev/job/3rdparty_libraries-interface/268/downstreambuildview/
3rdparty vTest x86: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/dev/job/3rdparty_libraries-interface/269/downstreambuildview/