### PR TITLE
Provide scheduler_ptr to _ScheduleFuncWithAutoInline

### DIFF
--- a/Release/include/pplx/pplx.h
+++ b/Release/include/pplx/pplx.h
@@ -176,7 +176,7 @@ public:
     scheduler_ptr _GetScheduler() const { return _M_pScheduler; }
 
     // Fire and forget
-    static void _RunTask(TaskProc_t _Proc, void* _Parameter, _TaskInliningMode _InliningMode)
+    static void _RunTask(TaskProc_t _Proc, void* _Parameter, _TaskInliningMode _InliningMode, scheduler_ptr _Scheduler)
     {
         if (_InliningMode == _ForceInline)
         {
@@ -184,8 +184,16 @@ public:
         }
         else
         {
-            // Schedule the work on the ambient scheduler
-            get_ambient_scheduler()->schedule(_Proc, _Parameter);
+            if (_Scheduler.get())
+            {
+                // Schedule the work on the desired scheduler
+                _Scheduler->schedule(_Proc, _Parameter);
+            }
+            else
+            {
+                // Schedule the work on the ambient scheduler as a fallback
+                get_ambient_scheduler()->schedule(_Proc, _Parameter);
+            }
         }
     }
 

--- a/Release/include/pplx/pplxtasks.h
+++ b/Release/include/pplx/pplxtasks.h
@@ -603,7 +603,10 @@ private:
 /// <param name="_InliningMode">
 ///     The inlining scheduling policy for current functor.
 /// </param>
-void _ScheduleFuncWithAutoInline(const std::function<void()>& _Func, _TaskInliningMode_t _InliningMode);
+/// <param name="_Scheduler">
+///     The intended Scheduler to run the task on.
+/// </param>
+void _ScheduleFuncWithAutoInline(const std::function<void()>& _Func, _TaskInliningMode_t _InliningMode, scheduler_ptr _Scheduler);
 
 class _ContextCallback
 {
@@ -1671,7 +1674,7 @@ struct _Task_impl : public _Task_impl_base
             if (_M_Continuations)
             {
                 // Scheduling cancellation with automatic inlining.
-                _ScheduleFuncWithAutoInline([=]() { _RunTaskContinuations(); }, details::_DefaultAutoInline);
+                _ScheduleFuncWithAutoInline([=]() { _RunTaskContinuations(); }, details::_DefaultAutoInline, _M_TaskCollection._GetScheduler());
             }
         }
         return true;

--- a/Release/src/pplx/pplxtasks.cpp
+++ b/Release/src/pplx/pplxtasks.cpp
@@ -79,9 +79,9 @@ namespace details
     delete _M_pThunk;
   }
 
-  void _ScheduleFuncWithAutoInline(const std::function<void()> & _Func, _TaskInliningMode_t _InliningMode)
+  void _ScheduleFuncWithAutoInline(const std::function<void()> & _Func, _TaskInliningMode_t _InliningMode, scheduler_ptr _Scheduler)
   {
-    _TaskCollection_t::_RunTask(&_TaskProcThunk::_Bridge, new _TaskProcThunk(_Func), _InliningMode);
+    _TaskCollection_t::_RunTask(&_TaskProcThunk::_Bridge, new _TaskProcThunk(_Func), _InliningMode, _Scheduler);
   }
 
 #if defined (__cplusplus_winrt)
@@ -965,7 +965,8 @@ namespace details
           }
           }
         },
-        _PTaskHandle->_M_inliningMode);
+        _PTaskHandle->_M_inliningMode,
+        _M_TaskCollection._GetScheduler());
       }
     else
     {


### PR DESCRIPTION
The ambient_scheduler may not be the desired scheduler to schedule
functions on, but _ScheduleFuncWithAutoInline does not offer any
other option. Provide a means to select a desired scheduler and
fall back to the ambient scheduler if not specified.

vTest 3rdparty build: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/525/downstreambuildview/
* vTest w/3rdparty archive:
* sanity+selected cpps: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/31062/downstreambuildview/
* c_api functional 1: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/31119/downstreambuildview/
* c_api functional 2: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/31120/downstreambuildview/
* c_api functional 3: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/31121/downstreambuildview/