### PR TITLE
Preserve original casing, don't lowercase scheme or host

### DIFF
--- a/Release/include/cpprest/base_uri.h
+++ b/Release/include/cpprest/base_uri.h
@@ -301,8 +301,10 @@ public:
     /// <returns><c>true</c> if this URI references the local host, <c>false</c> otherwise.</returns>
     bool is_host_loopback() const
     {
+        auto host = this->host();
+        utility::details::inplace_tolower(host);
         return !is_empty() &&
-               ((host() == _XPLATSTR("localhost")) || (host().size() > 4 && host().substr(0, 4) == _XPLATSTR("127.")));
+               ((host == _XPLATSTR("localhost")) || (host.size() > 4 && host.substr(0, 4) == _XPLATSTR("127.")));
     }
 
     /// <summary>

--- a/Release/src/uri/uri.cpp
+++ b/Release/src/uri/uri.cpp
@@ -766,6 +766,15 @@ bool uri::operator==(const uri& other) const
     // Each individual URI component must be decoded before performing comparison.
     // TFS # 375865
 
+    auto this_scheme_lower = this->scheme();
+    utility::details::inplace_tolower(this_scheme_lower);
+    auto other_scheme_lower = other.scheme();
+    utility::details::inplace_tolower(other_scheme_lower);
+    auto this_host_lower = this->host();
+    utility::details::inplace_tolower(this_host_lower);
+    auto other_host_lower = other.host();
+    utility::details::inplace_tolower(other_host_lower);
+
     if (this->is_empty() && other.is_empty())
     {
         return true;
@@ -774,7 +783,7 @@ bool uri::operator==(const uri& other) const
     {
         return false;
     }
-    else if (this->scheme() != other.scheme())
+    else if (this_scheme_lower != other_scheme_lower)
     {
         // scheme is canonicalized to lowercase
         return false;
@@ -783,7 +792,7 @@ bool uri::operator==(const uri& other) const
     {
         return false;
     }
-    else if (uri::decode(this->host()) != uri::decode(other.host()))
+    else if (uri::decode(this_host_lower) != uri::decode(other_host_lower))
     {
         // host is canonicalized to lowercase
         return false;

--- a/Release/src/uri/uri.cpp
+++ b/Release/src/uri/uri.cpp
@@ -337,7 +337,6 @@ struct inner_parse_out
         if (scheme_begin)
         {
             components.m_scheme.assign(scheme_begin, scheme_end);
-            utility::details::inplace_tolower(components.m_scheme);
         }
         else
         {
@@ -352,7 +351,6 @@ struct inner_parse_out
         if (host_begin)
         {
             components.m_host.assign(host_begin, host_end);
-            utility::details::inplace_tolower(components.m_host);
         }
         else
         {
@@ -475,11 +473,6 @@ void removeDotSegments(uri_builder& builder)
 utility::string_t uri_components::join()
 {
     // canonicalize components first
-
-    // convert scheme to lowercase
-    utility::details::inplace_tolower(m_scheme);
-    // convert host to lowercase
-    utility::details::inplace_tolower(m_host);
 
     // canonicalize the path to have a leading slash if it's a full uri
     if (!m_host.empty() && m_path.empty())

--- a/Release/tests/functional/uri/constructor_tests.cpp
+++ b/Release/tests/functional/uri/constructor_tests.cpp
@@ -133,17 +133,17 @@ SUITE(constructor_tests)
     // Tests a variety of different URIs using the examples in RFC 2732
     TEST(RFC_2732_examples_string)
     {
-        // The URI parser will make characters lower case
+        // The URI parser will keep the original casing
         uri http1(U("http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/index.html"));
         VERIFY_ARE_EQUAL(U("http"), http1.scheme());
-        VERIFY_ARE_EQUAL(U("[fedc:ba98:7654:3210:fedc:ba98:7654:3210]"), http1.host());
+        VERIFY_ARE_EQUAL(U("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]"), http1.host());
         VERIFY_ARE_EQUAL(80, http1.port());
         VERIFY_ARE_EQUAL(U("/index.html"), http1.path());
         VERIFY_ARE_EQUAL(U(""), http1.query());
 
         uri http2(U("http://[1080:0:0:0:8:800:200C:417A]/index.html"));
         VERIFY_ARE_EQUAL(U("http"), http2.scheme());
-        VERIFY_ARE_EQUAL(U("[1080:0:0:0:8:800:200c:417a]"), http2.host());
+        VERIFY_ARE_EQUAL(U("[1080:0:0:0:8:800:200C:417A]"), http2.host());
         VERIFY_ARE_EQUAL(0, http2.port());
         VERIFY_ARE_EQUAL(U("/index.html"), http2.path());
         VERIFY_ARE_EQUAL(U(""), http2.query());
@@ -164,21 +164,21 @@ SUITE(constructor_tests)
 
         uri http5(U("http://[1080::8:800:200C:417A]/foo"));
         VERIFY_ARE_EQUAL(U("http"), http5.scheme());
-        VERIFY_ARE_EQUAL(U("[1080::8:800:200c:417a]"), http5.host());
+        VERIFY_ARE_EQUAL(U("[1080::8:800:200C:417A]"), http5.host());
         VERIFY_ARE_EQUAL(0, http5.port());
         VERIFY_ARE_EQUAL(U("/foo"), http5.path());
         VERIFY_ARE_EQUAL(U(""), http5.query());
 
         uri http6(U("http://[::FFFF:129.144.52.38]:80/index.html"));
         VERIFY_ARE_EQUAL(U("http"), http6.scheme());
-        VERIFY_ARE_EQUAL(U("[::ffff:129.144.52.38]"), http6.host());
+        VERIFY_ARE_EQUAL(U("[::FFFF:129.144.52.38]"), http6.host());
         VERIFY_ARE_EQUAL(80, http6.port());
         VERIFY_ARE_EQUAL(U("/index.html"), http6.path());
         VERIFY_ARE_EQUAL(U(""), http6.query());
 
         uri http7(U("http://[2010:836B:4179::836B:4179]"));
         VERIFY_ARE_EQUAL(U("http"), http7.scheme());
-        VERIFY_ARE_EQUAL(U("[2010:836b:4179::836b:4179]"), http7.host());
+        VERIFY_ARE_EQUAL(U("[2010:836B:4179::836B:4179]"), http7.host());
         VERIFY_ARE_EQUAL(0, http7.port());
         VERIFY_ARE_EQUAL(U("/"), http7.path());
         VERIFY_ARE_EQUAL(U(""), http7.query());


### PR DESCRIPTION
This came up while testing the resolution of certain rest endpoints. E.g., when determining the server rest info endpoint given a particular URL, we had checks such as:

```
// Simplified example but you get the gist
std::string server_info_url(std::string uri)
{
   auto web_uri = web::uri(uri);
   auto ret_url = web_uri.authority().append("/sharing/rest/info");
   return ret_url;
}

ASSERT_EQ("https://www.ArcGIS.com/sharing/rest/info", server_info_url("https://www.ArcGIS.com/home"));
```

That check currently fails because web::uri is lowercasing the scheme and host as part of its parsing logic. In general we feel this goes against the "get what you set" mentality, since we are arbitrarily changing the casing of the user's input when we don't need to.

@parkske Shared this tidbit with me, and maybe is the reason they're doing it:

> Was curious what the URI spec says: https://datatracker.ietf.org/doc/html/rfc3986. Seems like they might be adhering to these guidelines:
Although host is case-insensitive, producers and normalizers should use lowercase
Although schemes are case-insensitive, the canonical form is lowercase and documents that
specify schemes must do so with lowercase letters.  An implementation
should accept uppercase letters as equivalent to lowercase in scheme
names (e.g., allow "HTTP" as well as "http") for the sake of
robustness but should only produce lowercase scheme names for
consistency.

Worth noting, this feedback is coming from a Swift developer, and they stated that the [Swift implemention of URI](https://swiftpackageindex.com/my-mail-ru/swift-URI) is not modifying the casing that the user provides. E.g. Swift's URI behaves thusly:

```
let url = URL(string: "HTTPS://www.ABC.com/test/mypath")
    print("scheme: \(url?.scheme)")
    print("host: \(url?.host)")
    print("path: \(url?.path)")
scheme: Optional("HTTPS")
host: Optional("www.ABC.com")
path: Optional("/test/mypath")
```

@airaolagoitia @parkske @cfrankmiller As you've interacted with URI stuff / this 3rdparty, I'd like your input on this change