### PR TITLE
cpprestsdk: Enable access to get_defaut_reason_phrase

### DIFF
--- a/Release/include/cpprest/details/http_helpers.h
+++ b/Release/include/cpprest/details/http_helpers.h
@@ -29,7 +29,6 @@ namespace details
 /// </summary>
 utility::string_t get_default_reason_phrase(status_code code);
 
-
 namespace chunked_encoding
 {
 // Transfer-Encoding: chunked support

--- a/Release/include/cpprest/details/http_helpers.h
+++ b/Release/include/cpprest/details/http_helpers.h
@@ -24,6 +24,12 @@ namespace http
 {
 namespace details
 {
+/// <summary>
+/// Helper function to get the default HTTP reason phrase for a status code.
+/// </summary>
+utility::string_t get_default_reason_phrase(status_code code);
+
+
 namespace chunked_encoding
 {
 // Transfer-Encoding: chunked support

--- a/Release/src/http/common/internal_http_helpers.h
+++ b/Release/src/http/common/internal_http_helpers.h
@@ -14,11 +14,6 @@ namespace http
 {
 namespace details
 {
-/// <summary>
-/// Helper function to get the default HTTP reason phrase for a status code.
-/// </summary>
-utility::string_t get_default_reason_phrase(status_code code);
-
 // simple helper functions to trim whitespace.
 template<class Char>
 void trim_whitespace(std::basic_string<Char>& str)


### PR DESCRIPTION
* allows the use of `web::http::details::get_default_reason_phrase()` in order to retrieve the default messages associated with HTTP status codes.