### PR TITLE
Store task handle before scheduling to avoid potential race with inlining logic

### DIFF
--- a/Release/include/pplx/pplx.h
+++ b/Release/include/pplx/pplx.h
@@ -143,6 +143,9 @@ public:
         }
         else
         {
+            // Store the task first before scheduling, otherwise a potential race condition
+            // could occur between storing _M_scheduled_task here and _M_scheduled_task being
+            // set to nullptr in _Complete(). 
             _M_scheduled_task.store(_PTaskHandle);
             _M_pScheduler->schedule(_TaskProcHandle_t::_RunChoreBridge, _PTaskHandle);
         }

--- a/Release/include/pplx/pplx.h
+++ b/Release/include/pplx/pplx.h
@@ -143,8 +143,8 @@ public:
         }
         else
         {
-            _M_pScheduler->schedule(_TaskProcHandle_t::_RunChoreBridge, _PTaskHandle);
             _M_scheduled_task.store(_PTaskHandle);
+            _M_pScheduler->schedule(_TaskProcHandle_t::_RunChoreBridge, _PTaskHandle);
         }
     }
 


### PR DESCRIPTION
Issue: https://devtopia.esri.com/runtime/red-october/issues/1609

[Relevant slack discussion](https://esri-runtime.slack.com/archives/C01LZV2N9DM/p1707837683316439)
`_PTaskHandle` is passed to the scheduler, once the task is executed `_TaskCollectionImpl::_Complete()` is called. This clears out the  `_M_scheduled_task` held in `_TaskCollectionImpl`. If that happens before the task is stored `_M_scheduled_task.store(_PTaskHandle)`, then when `_TaskCollectionImpl::_RunAndWait()` is called it will end up running the task inline.
The fix here just ensures the pointer is stored before the scheduler is called. Then if the task is executed immediately, the stored task will be cleared correctly and any subsequent calls to `_RunAndWait()` won't attempt to execute the task again.

3rdparty vtest: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/842/downstreambuildview/
RTC vtest of repro test without this fix: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/18302/downstreambuildview/
RTC vtest of repro test with this fix: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/18304/downstreambuildview/
RTC vtest with this fix: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/18314/downstreambuildview/