### PR TITLE
Mark ancestor task mutable

### DIFF
--- a/Release/include/pplx/pplxtasks.h
+++ b/Release/include/pplx/pplxtasks.h
@@ -3046,7 +3046,7 @@ private:
         typedef typename details::_NormalizeVoidToUnitType<_ContinuationReturnType>::_Type
             _NormalizedContinuationReturnType;
 
-        typename details::_Task_ptr<_ReturnType>::_Type _M_ancestorTaskImpl;
+        mutable typename details::_Task_ptr<_ReturnType>::_Type _M_ancestorTaskImpl;
         typename details::_CopyableFunctor<typename std::decay<_Function>::type>::_Type _M_function;
 
         template<class _ForwardedFunction>


### PR DESCRIPTION
Issue: https://devtopia.esri.com/runtime/home-one/issues/3266

The continuation task was keeping it's ancestor task result alive for the lifetime of the continuation task. I think the [original intent](https://github.com/Esri/cpprestsdk/blob/3d393d4f8e4752f8931bc944090ad02de3c3b59a/Release/include/pplx/pplxtasks.h#L3203-L3207) was for it to only keep it alive long enough to execute the continuation's lambda. However, that method is marked `const` thus the `std::move` copied the ancestor task instead of moving it.
This lifetime extension caused a race condition between the continuation thread and any threads waiting on the continuation. The pplx continuation task logic first executes the lambda, then signals any other threads that are waiting. Since the continuation kept the ancestor task alive, it might destroy the ancestor task result on either the waiting thread or the continuation thread (depending on which exited later).

The fix here should result in the ancestor task result always being destroyed on the waiting thread.

3rdparty vtest: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1228/downstreambuildview/
vtest of repro cases with fix: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/29290/downstreambuildview/
vtest of repro cases without fix: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/29294/downstreambuildview/
