### PR TITLE
Only release registration when previously registered

### DIFF
--- a/Release/include/pplx/pplxcancellation_token.h
+++ b/Release/include/pplx/pplxcancellation_token.h
@@ -305,11 +305,11 @@ protected:
             _M_last = node;
         }
 
-        void remove(_CancellationTokenRegistration* token)
+        [[nodiscard]] bool remove(_CancellationTokenRegistration* token)
         {
             Node* node = _M_begin;
             Node* prev = nullptr;
-
+            bool freed{false};
             while (node != nullptr)
             {
                 if (node->_M_token == token)
@@ -329,12 +329,14 @@ protected:
                     }
 
                     ::free(node);
+                    freed = true;
                     break;
                 }
 
                 prev = node;
                 node = node->_M_next;
             }
+            return freed;
         }
 
     private:
@@ -442,9 +444,11 @@ public:
             //
             if (!_M_registrations.empty())
             {
-                _M_registrations.remove(_PRegistration);
-                _PRegistration->_M_state = _CancellationTokenRegistration::_STATE_SYNCHRONIZE;
-                _PRegistration->_Release();
+                if (_M_registrations.remove(_PRegistration))
+                {
+                  _PRegistration->_M_state = _CancellationTokenRegistration::_STATE_SYNCHRONIZE;
+                  _PRegistration->_Release();
+                }
             }
             else
             {


### PR DESCRIPTION
In the case an "on cancel" registration is attempted while the cancel token is being canceled, the registration may be bypassed and the callback of the registration invoked immediately instead. As part of invoking the callback, the registration object is released (dealloc). When this occurs, at teardown of the token, a deregistration attempt occurs on the same registration object, which results in the use of memory already freed. To avoid this scenario at teardown, return a bool from the attempt to deregister and optionally release the registration, in case it was already released.

3rdparty build: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty-interface/1239/downstreambuildview/
vTests: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/29618/, https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/29619/, https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/29620/, https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/29621/