### PR TITLE
windows: Remove stdext deprecated calls

### DIFF
--- a/Release/include/cpprest/containerstream.h
+++ b/Release/include/cpprest/containerstream.h
@@ -399,12 +399,7 @@ private:
         auto readBegin = std::begin(m_data) + m_current_position;
         auto readEnd = std::begin(m_data) + newPos;
 
-#if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL != 0
-        // Avoid warning C4996: Use checked iterators under SECURE_SCL
-        std::copy(readBegin, readEnd, stdext::checked_array_iterator<_CharType*>(ptr, count));
-#else
         std::copy(readBegin, readEnd, ptr);
-#endif // _WIN32
 
         if (advance)
         {

--- a/Release/include/cpprest/producerconsumerstream.h
+++ b/Release/include/cpprest/producerconsumerstream.h
@@ -438,12 +438,7 @@ private:
             _CharType* beg = rbegin();
             _CharType* end = rbegin() + countRead;
 
-#if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL != 0
-            // Avoid warning C4996: Use checked iterators under SECURE_SCL
-            std::copy(beg, end, stdext::checked_array_iterator<_CharType*>(dest, count));
-#else
             std::copy(beg, end, dest);
-#endif // _WIN32
 
             if (advance)
             {
@@ -461,12 +456,7 @@ private:
 
             const _CharType* srcEnd = src + countWritten;
 
-#if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL != 0
-            // Avoid warning C4996: Use checked iterators under SECURE_SCL
-            std::copy(src, srcEnd, stdext::checked_array_iterator<_CharType*>(wbegin(), static_cast<size_t>(avail)));
-#else
             std::copy(src, srcEnd, wbegin());
-#endif // _WIN32
 
             update_write_head(countWritten);
             return countWritten;

--- a/Release/include/cpprest/rawptrstream.h
+++ b/Release/include/cpprest/rawptrstream.h
@@ -439,12 +439,7 @@ private:
         auto readBegin = m_data + m_current_position;
         auto readEnd = m_data + newPos;
 
-#if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL != 0
-        // Avoid warning C4996: Use checked iterators under SECURE_SCL
-        std::copy(readBegin, readEnd, stdext::checked_array_iterator<_CharType*>(ptr, count));
-#else
         std::copy(readBegin, readEnd, ptr);
-#endif // _WIN32
 
         if (advance)
         {
@@ -466,12 +461,7 @@ private:
         if (newSize > m_size) throw std::runtime_error("Writing past the end of the buffer");
 
             // Copy the data
-#if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL != 0
-        // Avoid warning C4996: Use checked iterators under SECURE_SCL
-        std::copy(ptr, ptr + count, stdext::checked_array_iterator<_CharType*>(m_data, m_size, m_current_position));
-#else
         std::copy(ptr, ptr + count, m_data + m_current_position);
-#endif // _WIN32
 
         // Update write head and satisfy pending reads if any
         update_current_position(newSize);


### PR DESCRIPTION
@cwarner-8702 hit issues using the newly released 14.51 msvc toolchain that has removed the deprecated stdext check iterator type that was introduced 7 years [ago](https://github.com/microsoft/cpprestsdk/pull/1072/changes).

Remove these codepaths completely as they no longer produce any warnings.

```
16>C:\Projects\3rdparty\cpprestsdk\Release\include\cpprest\containerstream.h(404,39): error C2065: 'stdext': undeclared identifier
16>  (compiling source file '../common/CMakeFiles/common.dir/cmake_pch.cxx')
16>      C:\Projects\3rdparty\cpprestsdk\Release\include\cpprest\containerstream.h(404,39):
16>      the template instantiation context (the oldest one first) is
16>          C:\Projects\3rdparty\cpprestsdk\Release\include\cpprest\containerstream.h(44,7):
16>          while compiling class template 'Concurrency::streams::details::basic_container_buffer'
```